### PR TITLE
Update ShinyGUIClass.R

### DIFF
--- a/R/ShinyGUIClass.R
+++ b/R/ShinyGUIClass.R
@@ -38,7 +38,7 @@ ShinyGUI <- setRefClass("ShinyGUI",
                               forced_choice <<- TRUE
                               theme <<- ''
                               Timer <- as.numeric(Timer)
-                              timer <<- ifelse(is.finite(Timer), Timer, as.numeric(NA))
+                              timer <<- ifelse(is.finite(Timer), Timer, as.numeric(0))
                               if(length(CustomTypes)){
                                   if(length(CustomTypes) != length(unique(names(CustomTypes))))
                                       stop('customTypes list requires unique names for each function', call.=FALSE)


### PR DESCRIPTION
Hi Phil! I think I have found a bug and a potential solution. 

Replacing `NA` with `0` circumvents an error that arises when using `Inf` on the timer: `"Error: missing value where TRUE/FALSE needed"`. As far as I can tell, the error arises because server.R line 43:

`if(!is.null(item) && .MCE[[sessionName]]$shinyGUI$timer[item] > 0)`

This if statement cannot take NA as an input and therefore throws an error. 

What do you think? 

In order to recreate the bug, just use the latest `mirtCAT` version and supply the timer with `Inf` time. 
![pic](https://user-images.githubusercontent.com/50638827/92745017-45c41d80-f382-11ea-9c37-8c24176d662a.png)
