### PR TITLE
Item Timer Stop

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -50,7 +50,7 @@ server <- function(input, output, session) {
     output$itemTime <- renderText({
         printDebug("itemTime", 3)
         invalidateLater(200, session)
-        if(.MCE[[sessionName]]$person$terminated_sucessfully)
+        if(.MCE[[sessionName]]$STOP)
             return(NULL)
         item <- .MCE[[sessionName]]$item
         delta_msg <- .MCE[[sessionName]]$shinyGUI$timemsg


### PR DESCRIPTION
Changed the criteria for stopping the item time GUI. During adaptive test the `person$terminated_sucessfully` does not == T until the test is closed. If you use an adaptive test and reach the `lastpage`, the `itemtime `continous to run. Please let me know if i am not making any sense and you need a reproducible example of this. 

Also please not that this solves the problem with the `itemtime`, but I am not certain that it doesnt crash something else... Does it make sense from your perspective?
Sincerely
Magnus Nordmo